### PR TITLE
Update docs for modern IaC best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,12 @@ This tutorial is not meant to give a complete guide on how to use a specific too
 
 _See [my presentation at DevOpsDays Silicon Valley](https://www.youtube.com/watch?v=XbcW2B7roLo&t=) in which I talk more in depth about the tutorial._
 
-## Need your help!
+## Project History
 
-This tutorial was created in 2018 and wasn't being kept up to date. Therefore, some of the instructions may not work due to updated APIs, obsolete repositories, etc. I apologize for that, but I currently don't have time to update this tutorial. So if you find that something is broken and you find a fix, please submit a PR. 
-
-When submitting a PR, make sure you include a description for it, i.e. what's broken and a test plan for the fix.
-
-Also, note that some of things need to be updated in several different repositories at the same time. Main repositories used in this tutorial:
-
-* https://github.com/Artemmkin/infrastructure-as-code-tutorial
-* https://github.com/Artemmkin/infrastructure-as-code-example
-* https://github.com/Artemmkin/raddit
+This project is a fork of [Artemmkin/infrastructure-as-code-tutorial](https://github.com/Artemmkin/infrastructure-as-code-tutorial).
+The content has been refreshed to align with current best practices and newer
+versions of the tools used throughout the labs.
+Improvements and clarifications have been added where necessary.
 
 ## Target Audience
 

--- a/docs/00-introduction.md
+++ b/docs/00-introduction.md
@@ -1,17 +1,11 @@
 # Introduction
 
-Let's dream for a little bit...
+Welcome to the Infrastructure as Code tutorial.  The goal of this guide is to
+show how modern operations teams manage infrastructure through code rather than
+manual commands.  We will start with basic manual tasks and progressively
+introduce tools that automate provisioning and configuration.
 
-Imagine that you're a young developer who developed a web application. You run and test your application locally and everything works great, which makes you very happy. You believe that this is going to blow the minds of Internet users and bring you a lot of money.
-
-Then you realize that there is a small problem. You ask yourself a question: "How do I make my application available to the Internet users?"
-
-You're thinking that you can't run the application locally all the time, because your old laptop will become slow for other tasks and will probably crash if a lot of users will be using your app at the same time. Besides, your ISP changes randomly the public IP for your router, so you don't know on which IP address your application will be accessible to the public at any given moment.
-
-You start realizing that the problem you're facing is not as small as you thought. In fact, there is a whole new craft for you to learn in IT world about running software applications and making sure they are always available to the users.
-
-The craft is called **IT operations**. And in almost every IT department, there is an operations (Ops) team who manages the platform where the applications are running.
-
-The tutorial you are about to begin will give you, a young developer, a bit of a glance into what operations work look like and how you can do this work more efficiently by using **Infrastructure as Code** approach.
+By the end you will understand the core ideas behind **Infrastructure as Code**
+and how it helps deliver reliable systems in a repeatable manner.
 
 Next: [Prerequisites](01-prerequisites.md)

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -10,7 +10,7 @@ In this tutorial, we use the [Google Cloud Platform](https://cloud.google.com/) 
 
 Follow the Google Cloud SDK [documentation](https://cloud.google.com/sdk/) to install and configure the `gcloud` command line utility for your platform.
 
-Verify the Google Cloud SDK version is 183.0.0 or higher:
+Verify the Google Cloud SDK version is 453.0.0 or higher:
 
 ```bash
 $ gcloud version

--- a/docs/02-manual-operations.md
+++ b/docs/02-manual-operations.md
@@ -16,11 +16,11 @@ You've signed up for a free tier of [Google Cloud Platform](https://cloud.google
 
 First thing we will do is to provision a virtual machine (VM) inside GCP for running the application.
 
-Use the following gcloud command in your terminal to launch a VM with Ubuntu 16.04 distro:
+Use the following gcloud command in your terminal to launch a VM with Ubuntu 22.04 LTS:
 
 ```bash
 $ gcloud compute instances create raddit-instance-2 \
-    --image-family ubuntu-1604-lts \
+    --image-family ubuntu-2204-lts \
     --image-project ubuntu-os-cloud \
     --boot-disk-size 10GB \
     --machine-type n1-standard-1
@@ -89,7 +89,7 @@ Clone the [application repo](https://github.com/Artemmkin/raddit), but first mak
 $ git version
 ```
 
-At the time of writing the latest image of Ubuntu 16.04 which GCP provides has `git` preinstalled, so we can skip this step.
+At the time of writing the latest image of Ubuntu 22.04 provided by GCP already has `git` preinstalled, so we can skip this step.
 
 Clone the application repo into the home directory of `raddit-user` user:
 
@@ -109,8 +109,8 @@ $ sudo bundle install
 Install MongoDB which your application uses:
 
 ```bash
-$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-$ echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+$ wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+$ echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 $ sudo apt-get update
 $ sudo apt-get install -y mongodb-org
 ```

--- a/docs/03-scripts.md
+++ b/docs/03-scripts.md
@@ -18,7 +18,7 @@ Start a new VM for this lab. The command should look familiar:
 
 ```bash
 $ gcloud compute instances create raddit-instance-3 \
-    --image-family ubuntu-1604-lts \
+    --image-family ubuntu-2204-lts \
     --image-project ubuntu-os-cloud \
     --boot-disk-size 10GB \
     --machine-type n1-standard-1
@@ -66,8 +66,8 @@ apt-get install -y ruby-full build-essential
 gem install --no-rdoc --no-ri bundler
 
 echo "  ----- install mongodb -----  "
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" > /etc/apt/sources.list.d/mongodb-org-3.2.list
+wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" > /etc/apt/sources.list.d/mongodb-org-6.0.list
 apt-get update
 apt-get install -y mongodb-org
 

--- a/docs/04-packer.md
+++ b/docs/04-packer.md
@@ -44,10 +44,10 @@ Create a `raddit-base-image.json` file inside the `packer` directory with the fo
       "project_id": "infrastructure-as-code",
       "zone": "europe-west1-b",
       "machine_type": "g1-small",
-      "source_image_family": "ubuntu-1604-lts",
+      "source_image_family": "ubuntu-2204-lts",
       "image_name": "raddit-base-{{isotime `20060102-150405`}}",
       "image_family": "raddit-base",
-      "image_description": "Ubuntu 16.04 with Ruby, Bundler and MongoDB preinstalled",
+      "image_description": "Ubuntu 22.04 with Ruby, Bundler and MongoDB preinstalled",
       "ssh_username": "raddit-user"
     }
   ]
@@ -78,10 +78,10 @@ Your template should look similar to this one:
       "project_id": "infrastructure-as-code",
       "zone": "europe-west1-b",
       "machine_type": "g1-small",
-      "source_image_family": "ubuntu-1604-lts",
+      "source_image_family": "ubuntu-2204-lts",
       "image_name": "raddit-base-{{isotime `20060102-150405`}}",
       "image_family": "raddit-base",
-      "image_description": "Ubuntu 16.04 with Ruby, Bundler and MongoDB preinstalled",
+      "image_description": "Ubuntu 22.04 with Ruby, Bundler and MongoDB preinstalled",
       "ssh_username": "raddit-user"
     }
   ],

--- a/docs/05-terraform.md
+++ b/docs/05-terraform.md
@@ -40,7 +40,7 @@ The second problem is dealt by source control tools like `git`, while the first 
 
 [Download](https://www.terraform.io/downloads.html) and install Terraform on your system.
 
-Make sure Terraform version is  => 0.11.0:
+Make sure Terraform version is  => 1.5.0:
 
 ```bash
 $ terraform -v
@@ -95,7 +95,7 @@ Create another file inside `terraform` folder and call it `providers.tf`. Put pr
 
 ```
 provider "google" {
-  version = "~> 1.4.0"
+  version = "~> 5.0"
   project = "infrastructure-as-code"
   region  = "europe-west1"
 }

--- a/docs/07-vagrant.md
+++ b/docs/07-vagrant.md
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
   end
   # define a VM machine configuration
   config.vm.define "raddit-app" do |app|
-    app.vm.box = "ubuntu/xenial64"
+    app.vm.box = "ubuntu/jammy64"
     app.vm.hostname = "raddit-app"
   end
 end
@@ -78,14 +78,14 @@ We also specify characteristics of a VM we want to launch: what machine image (`
 ```ruby
 # define a VM machine configuration
 config.vm.define "raddit-app" do |app|
-  app.vm.box = "ubuntu/xenial64"
+  app.vm.box = "ubuntu/jammy64"
   app.vm.hostname = "raddit-app"
 end
 ```
 
 ## Start a Local VM
 
-With the Vagrantfile created, you can start a VM on your local machine using Ubuntu 16.04 image from Vagrant Cloud.
+With the Vagrantfile created, you can start a VM on your local machine using Ubuntu 22.04 image from Vagrant Cloud.
 
 Run the following command inside the folder with your Vagrantfile:
 
@@ -127,7 +127,7 @@ Vagrant.configure("2") do |config|
   end
   # define a VM configuration
   config.vm.define "raddit-app" do |app|
-    app.vm.box = "ubuntu/xenial64"
+    app.vm.box = "ubuntu/jammy64"
     app.vm.hostname = "raddit-app"
     # sync a local folder with application code to the VM folder
     app.vm.synced_folder "raddit-app/", "/srv/raddit-app"

--- a/docs/09-docker-compose.md
+++ b/docs/09-docker-compose.md
@@ -18,7 +18,7 @@ To make the management of our local container infrastructure easier and more rel
 
 Follow the official documentation on [how to install Docker Compose](https://docs.docker.com/compose/install/) on your system.
 
-Verify that installed version of Docker Compose is => 1.18.0:
+Verify that installed version of Docker Compose is => 2.20.0:
 
 ```bash
 $ docker-compose -v


### PR DESCRIPTION
## Summary
- modernize introduction and remove narrative style
- update manuals and scripts to use Ubuntu 22.04 and MongoDB 6.0
- refresh packer example with new base image
- bump Terraform, provider and Docker Compose versions
- update Vagrant boxes to jammy
- mention project history in README and credit the original repo

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f98f36a0883238c46f165d86d4a13